### PR TITLE
feat: ChatGPT APIをちゃんと使えるようにする

### DIFF
--- a/js/Summarizer.js
+++ b/js/Summarizer.js
@@ -1,48 +1,58 @@
-// ChatGPT APIのエンドポイントURL
-const API_URL = "https://api.openai.com/v1/engines/davinci-codex/completions";
 // ChatGPT APIの認証トークン
-const API_KEY = "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";
+const API_KEY = "＜APIキーを入力＞";
 
+// ChatGPTのAPIを呼び出すメソッド
+async function getChatGPT(apiKey, message) {
+  try {
+    const apiUrl = 'https://api.openai.com/v1/chat/completions';
+    const messages = [{ 'role': 'user', 'content': message }];
+    const headers = {
+      'Authorization': 'Bearer ' + apiKey,
+      'Content-type': 'application/json',
+      'X-Slack-No-Retry': 1
+    };
+    const options = {
+      // 'muteHttpExceptions': true,
+      'headers': headers,
+      'method': 'POST',
+      'body': JSON.stringify({
+        'model': 'gpt-3.5-turbo',
+        'max_tokens': 100,
+        'temperature': 0.7,
+        "n": 1,
+        'messages': messages
+      })
+    };
+    const response = await fetch(apiUrl, options)
+    const responseJson = await response.json()
+    return responseJson.choices[0].message.content.trim()
+  } catch (e) {
+    console.error("APIから要約を受け取れませんでした")
+    return undefined
+  }
+}
 
-// ページをロードした時に実行される関数
-window.onload = function () {
-  // WebページのURLを取得する
-  const url = window.location.href;
-  // APIに送信するデータを準備する
-  const data = {
-    "prompt": `summarize the webpage at ${url} and translate it into Japanese. +\nOnly Japanese is output.`,
-    "temperature": 0.7,
-    "max_tokens": 100,
-    "n": 1,
-    "stop": "\n"
-  };
-  // APIにリクエストを送信する
-  fetch(API_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${API_KEY}`
-    },
-    body: JSON.stringify(data)
-  })
-    .then(response => response.json())
-    .then(data => {
-      // APIから受け取った要約を四角枠に表示する
-      if (data.choices) {
-        const summary = data.choices[0].text.trim();
-        const rectangle = document.createElement("div");
-        rectangle.style.position = "fixed";
-        rectangle.style.top = "0";
-        rectangle.style.left = "0";
-        rectangle.style.width = "100%";
-        rectangle.style.height = "50px";
-        rectangle.style.backgroundColor = "#fff";
-        rectangle.style.border = "1px solid #000";
-        rectangle.style.padding = "10px";
-        rectangle.innerHTML = `<strong>Webページの要約:</strong> ${summary}`;
-        document.body.appendChild(rectangle);
-    } else 
-    console.error("APIから要約を受け取れませんでした。");
-  });
-    
+// ページをロードした時に実行されるメソッド
+window.onload = async function () {
+  const websiteUrl = window.location.href;
+
+  const prompt = `summarize the webpage at ${websiteUrl} and translate it into Japanese. +\nOnly Japanese is output.`
+  const summary = await getChatGPT(API_KEY, prompt)
+  console.log("確認:", summary);
+
+  if (summary === undefined) {
+    return
+  }
+
+  const rectangle = document.createElement("div");
+  rectangle.style.position = "fixed";
+  rectangle.style.top = "0";
+  rectangle.style.left = "0";
+  rectangle.style.width = "100%";
+  rectangle.style.height = "50px";
+  rectangle.style.backgroundColor = "#fff";
+  rectangle.style.border = "1px solid #000";
+  rectangle.style.padding = "10px";
+  rectangle.innerHTML = `<strong>Webページの要約:</strong> ${summary}`;
+  document.body.appendChild(rectangle);
 };


### PR DESCRIPTION
## 実装内容
- ChatGPT APIのURLを修正
  - Before: https://api.openai.com/v1/engines/davinci-codex/completions
  - After: https://api.openai.com/v1/chat/completions
- 実行時に発生していたundefinedエラーを修正
- その他リファクタリングなど

## スクリーンショット
<img width="800" alt="ss000696" src="https://user-images.githubusercontent.com/74450836/225599714-b7572a18-2b2b-4fba-889e-f897f0c1565d.png">

## 実行結果
https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000164708_00001.html での検証結果
```
Webページの要約: このウェブページは、厚生労働省が新型コロナウイルス感染症の対策に関する情報を提供している。主な内容は、感染症の基礎知識、感染拡大防止対策、医療関係者向け情報、および
```

## 参考にしたサイト
- ChatGPTのAPIについて：https://platform.openai.com/docs/api-reference/chat/create
- awaitを使ったfetchの書き方：https://zenn.dev/kawaxumax/articles/0044a0e30536e2
